### PR TITLE
Corrected country code regex match

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ interface SanitizeOptions {
 export const COUNTRY_CODE = "234";
 
 export const verifyPhoneNumber = (phone: string) => {
-	return /^([0]{1}|\+?[234]{3})([7-9]{1})([0|1]{1})([\d]{1})([\d]{7})$/g.test(String(phone));
+	return /^([0]{1}|\+?234)([7-9]{1})([0|1]{1})([\d]{1})([\d]{7})$/g.test(String(phone));
 };
 
 export const sanitizePhoneNumber = (phone: string, { mode = "throwInvalid" }: SanitizeOptions = {}) => {

--- a/src/tests/index.spec.ts
+++ b/src/tests/index.spec.ts
@@ -1,12 +1,19 @@
 import { sanitizePhoneNumber, verifyPhoneNumber } from "../index";
 
 describe("Nigerian Phone Number Validator", () => {
-	it("should verify valid phone numbers", () => {
+	it("should return true valid phone numbers", () => {
 		expect(verifyPhoneNumber("2348139922348")).toBe(true);
 	});
-	it("should verify invalid phone numbers", () => {
+
+	it("should return false for invalid phone numbers", () => {
 		expect(verifyPhoneNumber("23481399223486")).toBe(false);
+		expect(verifyPhoneNumber("2438139922348")).toBe(false);
+		expect(verifyPhoneNumber("3248139922348")).toBe(false);
+		expect(verifyPhoneNumber("3428139922348")).toBe(false);
+		expect(verifyPhoneNumber("4238139922348")).toBe(false);
+		expect(verifyPhoneNumber("4328139922348")).toBe(false);
 	});
+
 	it("should sanitize phone numbers", () => {
 		expect(sanitizePhoneNumber("08139922348")).toBe("2348139922348");
 		expect(sanitizePhoneNumber("2348139922348")).toBe("2348139922348");


### PR DESCRIPTION
Fixed a bug in the country code matcher that might result in false-positives for invalid country code combinations.

Fixes #5 